### PR TITLE
バージョンを各パートずつ分けて変数管理するよう変更 #4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 ﻿cmake_minimum_required (VERSION 3.12)
 
+set(VERSION_MAJOR 0)
+set(VERSION_MINOR 1)
+set(VERSION_PATCH 0)
+
 if (POLICY CMP0141)
   cmake_policy(SET CMP0141 NEW)
   set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<IF:$<AND:$<C_COMPILER_ID:MSVC>,$<CXX_COMPILER_ID:MSVC>>,$<$<CONFIG:Debug,RelWithDebInfo>:EditAndContinue>,$<$<CONFIG:Debug,RelWithDebInfo>:ProgramDatabase>>")
@@ -8,7 +12,7 @@ endif()
 FILE(GLOB src "src/*.c")
 FILE(GLOB include "include/*.h")
 
-project("pmalloc" VERSION 0.1.0 LANGUAGES C)
+project("pmalloc" VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH} LANGUAGES C)
 
 add_library (
 	${PROJECT_NAME}


### PR DESCRIPTION
Fix #4 
# 変更主旨
- バージョン番号をMajor部、Minor部、Patch部をそれぞれ別の変数で管理するようにし、Releaseアクションでバージョンが自動更新されるよう変更 2599ec53a1df875246f98283e7fc88a904ed3056